### PR TITLE
[T-7029][IMP] project_task_identification: store sy_id field.

### DIFF
--- a/project_task_identification/models/project_task.py
+++ b/project_task_identification/models/project_task.py
@@ -1,7 +1,7 @@
 # Copyright 2025 Ángel García de la Chica Herrera <angel.garcia@sygel.es>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ProjectTask(models.Model):
@@ -10,9 +10,11 @@ class ProjectTask(models.Model):
     sy_id = fields.Char(
         compute="_compute_sy_id",
         compute_sudo=True,
+        store=True,
         string="ID",
     )
 
+    @api.depends("create_date")
     def _compute_sy_id(self):
         for sel in self:
             sel.sy_id = "T-{}".format(sel.id)


### PR DESCRIPTION
IMP for _sy_id_ to be stored in the database and new test.