### PR TITLE
[18.0][T-8768][FIX] project_odoo_version: check active odoo version

### DIFF
--- a/project_odoo_version/models/project_project.py
+++ b/project_odoo_version/models/project_project.py
@@ -16,7 +16,7 @@ class Project(models.Model):
     @api.constrains("odoo_version")
     def _check_active_odoo_version(self):
         for sel in self:
-            if not sel.odoo_version.active:
+            if sel.odoo_version and not sel.odoo_version.active:
                 raise ValidationError(
                     _(
                         "You can choose only one active version. "


### PR DESCRIPTION
Without this FIX, the projects can raise errors if they doesn't have any odoo version

It seems that in v18, the constrains are more restrictive, and they are triggered in more cases